### PR TITLE
Add Initial Setup section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # Standard Project
 A template repo for the standard RSE project
 
+## >> INITIAL SETUP FOR NEW PROJECTS <<   
+
+When you create a new project, we recommend that you do the following additional manual steps (and then delete this section of the readme).
+
+- Add project details to  this Readme!
+
+- Go to Settings -> Code security and Analysis and enable "Dependabot Version Updates". This will automatically create Pull Requests to keep your dependencies up-to-date. To activate this feature, you will need to specify the package ecosystem (i.e. NPM) and save the YML file. 
+
+- Add a brief description of the project to the 'About' section (top right of this page). If your project involves a website, then add the URL here too.
+
 ## About
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin ante at eleifend eleifend. Sed non vestibulum nisi. Aliquam vel condimentum quam. Donec fringilla et purus at auctor. Praesent euismod vitae metus non consectetur. Sed interdum aliquet nisl at efficitur. Nulla urna quam, gravida eget elementum eget, mattis nec tortor. Fusce ut neque tellus. Integer at magna feugiat lacus porta posuere eget vitae metus.
-
-Curabitur a tempus arcu. Maecenas blandit risus quam, quis convallis justo pretium in. Suspendisse rutrum, elit at venenatis cursus, dolor ligula iaculis dui, ut dignissim enim justo at ligula. Donec interdum dignissim egestas. Nullam nec ultrices enim. Nam quis arcu tincidunt, auctor purus sit amet, aliquam libero. Fusce rhoncus lectus ac imperdiet varius. Sed gravida urna eros, ac luctus justo condimentum nec. Integer ultrices nibh in neque sagittis, at pretium erat pretium. Praesent feugiat purus id iaculis laoreet. Proin in tellus tristique, congue ante in, sodales quam. Sed imperdiet est tortor, eget vestibulum tortor pulvinar volutpat. In et pretium nisl.
 
 ### Project Team
 


### PR DESCRIPTION
This section gives instructions to RSEs on manual steps we recommend they take take when creating a new project - and then they should delete this section from the readme.

## Type of change

(Added new section to the template repo Readme)

## What should reviewers look for?

As discussed at the away day. What do we think about this? We could add other instructions to this list. Or link to the wiki and say "have you done everything on this wiki page"?

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
